### PR TITLE
Expand Convex schema with auctions, penny auctions, and services

### DIFF
--- a/RAPID_DEPLOY.md
+++ b/RAPID_DEPLOY.md
@@ -1,0 +1,184 @@
+# 2-Day Production Deployment
+
+## Quick Start
+
+```bash
+# Make script executable
+chmod +x scripts/rapid-deploy.sh
+
+# Run deployment
+./scripts/rapid-deploy.sh
+```
+
+## Day 1 Checklist (4-6 hours)
+
+### Hour 1: Setup
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Initialize Convex (creates project, gets URL)
+npx convex dev
+
+# 3. Add to .env
+CONVEX_URL=https://your-deployment.convex.cloud
+```
+
+### Hour 2: Deploy
+```bash
+# Deploy Convex functions
+npx convex deploy
+
+# Set OpenAI key for AI agents (optional)
+npx convex env set OPENAI_API_KEY sk-your-key
+```
+
+### Hour 3-5: Migrate Data
+```bash
+# Backup first!
+pg_dump $DATABASE_URL > backup.sql
+
+# Run migration
+npm run migrate:convex
+
+# Verify
+npm run verify:migration
+```
+
+### Hour 6: Test
+```bash
+# Start server
+npm run dev
+
+# Test endpoints
+curl http://localhost:5000/api/products
+curl http://localhost:5000/api/categories
+```
+
+## Day 2 Checklist (4-6 hours)
+
+### Hour 1-2: Enable Hybrid Mode
+```bash
+# Already done in server.js - just start the server
+npm run dev
+
+# Check logs for:
+# ✅ Convex backend enabled - hybrid mode active
+```
+
+### Hour 3: Update Stripe Webhooks
+1. Go to Stripe Dashboard → Webhooks
+2. Add endpoint: `https://your-deployment.convex.cloud/webhooks/stripe`
+3. Select events: `checkout.session.completed`, `payment_intent.payment_failed`
+
+### Hour 4-5: Smoke Test
+```bash
+# Test critical paths
+curl -X POST http://localhost:5000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"test"}'
+
+curl http://localhost:5000/api/products
+curl http://localhost:5000/api/categories
+```
+
+### Hour 6: Deploy
+```bash
+# Your normal deployment process
+# Heroku, Railway, Render, etc.
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Your Frontend                          │
+│                  (No changes needed!)                        │
+└─────────────────────────┬───────────────────────────────────┘
+                          │ REST API calls
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Express Server                            │
+│                    (server.js)                               │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │              convexService.js                        │    │
+│  │         (Bridge - tries Convex first)               │    │
+│  └────────────────┬────────────────────────────────────┘    │
+└───────────────────┼─────────────────────────────────────────┘
+                    │
+         ┌──────────┴──────────┐
+         ▼                     ▼
+┌─────────────────┐   ┌─────────────────┐
+│     CONVEX      │   │   PostgreSQL    │
+│   (Primary)     │   │   (Fallback)    │
+└─────────────────┘   └─────────────────┘
+```
+
+## Rollback (5 seconds)
+
+If anything breaks:
+
+```javascript
+// In server.js, comment out this line:
+// const convexEnabled = convexService.initializeConvex();
+
+// Replace with:
+const convexEnabled = false;
+```
+
+Or just unset the environment variable:
+```bash
+unset CONVEX_URL
+npm run dev
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `server.js` | Added Convex initialization |
+| `src/services/convexService.js` | Bridge to Convex |
+| `src/middleware/convexBridge.js` | Hybrid controller helper |
+| `src/controllers/productController.hybrid.js` | Example hybrid controller |
+
+## Success Criteria
+
+- [ ] `npm run dev` shows "Convex backend enabled"
+- [ ] `/api/products` returns data
+- [ ] `/api/auth/login` works
+- [ ] Convex dashboard shows queries
+- [ ] No errors in logs
+
+## Troubleshooting
+
+### "Convex not configured"
+```bash
+# Check .env has CONVEX_URL
+cat .env | grep CONVEX
+
+# Should show:
+# CONVEX_URL=https://xxx.convex.cloud
+```
+
+### "Migration failed"
+```bash
+# Check PostgreSQL connection
+psql $DATABASE_URL -c "SELECT 1"
+
+# Check Convex connection
+npx convex run products:getProducts --arg '{}'
+```
+
+### "Products not showing"
+```bash
+# Check Convex dashboard for data
+# Run migration if empty:
+npm run migrate:convex
+```
+
+## After Go-Live
+
+Once stable for 1 week:
+1. Run `npm run cleanup:legacy` to remove PostgreSQL
+2. Update frontend to use Convex directly (optional)
+3. Remove hybrid controller fallbacks

--- a/convex/_migration/migrateAuctions.ts
+++ b/convex/_migration/migrateAuctions.ts
@@ -1,0 +1,234 @@
+import { internalMutation, internalQuery } from "../_generated/server";
+import { v } from "convex/values";
+
+/**
+ * Auction Migration Utilities
+ *
+ * Migrates auction data from PostgreSQL to Convex:
+ * - Traditional auctions
+ * - Bids
+ * - Penny auctions
+ * - Penny bids
+ * - Bid packages
+ * - User bid balances
+ * - Bid transactions
+ * - Auto-bid configs
+ */
+
+// Migrate a traditional auction
+export const migrateAuction = internalMutation({
+  args: {
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    condition: v.optional(v.string()),
+    startingBid: v.number(),
+    currentBid: v.number(),
+    startTime: v.number(),
+    endTime: v.number(),
+    imageUrl: v.optional(v.string()),
+    sellerId: v.id("users"),
+    highestBidderId: v.optional(v.id("users")),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("completed"),
+      v.literal("cancelled")
+    ),
+    isDisabled: v.boolean(),
+    reservePrice: v.optional(v.number()),
+    buyNowPrice: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("auctions", args);
+  },
+});
+
+// Migrate a bid
+export const migrateBid = internalMutation({
+  args: {
+    auctionId: v.id("auctions"),
+    bidderId: v.id("users"),
+    amount: v.number(),
+    isWinning: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("bids", args);
+  },
+});
+
+// Migrate a penny auction
+export const migratePennyAuction = internalMutation({
+  args: {
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    imageUrl: v.optional(v.string()),
+    retailPrice: v.number(),
+    startingPrice: v.number(),
+    currentPrice: v.number(),
+    bidIncrement: v.number(),
+    bidCost: v.number(),
+    startTime: v.number(),
+    endTime: v.number(),
+    timerSeconds: v.number(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("completed"),
+      v.literal("cancelled")
+    ),
+    highestBidderId: v.optional(v.id("users")),
+    totalBids: v.number(),
+    isDisabled: v.boolean(),
+    sellerId: v.id("users"),
+    featured: v.boolean(),
+    winnerId: v.optional(v.id("users")),
+    finalPrice: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("pennyAuctions", args);
+  },
+});
+
+// Migrate a penny bid
+export const migratePennyBid = internalMutation({
+  args: {
+    pennyAuctionId: v.id("pennyAuctions"),
+    bidderId: v.id("users"),
+    bidAmount: v.number(),
+    bidCost: v.number(),
+    newPrice: v.number(),
+    timerExtended: v.boolean(),
+    isAutoBid: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("pennyBids", args);
+  },
+});
+
+// Migrate a bid package
+export const migrateBidPackage = internalMutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    bidCount: v.number(),
+    price: v.number(),
+    isActive: v.boolean(),
+    discountPercentage: v.number(),
+    imageUrl: v.optional(v.string()),
+    featured: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    // Check if package with same name exists
+    const existing = await ctx.db
+      .query("bidPackages")
+      .filter((q) => q.eq(q.field("name"), args.name))
+      .first();
+
+    if (existing) {
+      return existing._id;
+    }
+
+    return await ctx.db.insert("bidPackages", args);
+  },
+});
+
+// Migrate user bid balance
+export const migrateUserBidBalance = internalMutation({
+  args: {
+    userId: v.id("users"),
+    bidBalance: v.number(),
+    totalBidsPurchased: v.number(),
+    totalBidsUsed: v.number(),
+    lastPurchaseDate: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    // Check if balance exists
+    const existing = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        bidBalance: args.bidBalance,
+        totalBidsPurchased: args.totalBidsPurchased,
+        totalBidsUsed: args.totalBidsUsed,
+        lastPurchaseDate: args.lastPurchaseDate,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("userBidBalances", args);
+  },
+});
+
+// Migrate bid transaction
+export const migrateBidTransaction = internalMutation({
+  args: {
+    userId: v.id("users"),
+    bidPackageId: v.optional(v.id("bidPackages")),
+    transactionType: v.union(
+      v.literal("purchase"),
+      v.literal("use"),
+      v.literal("refund"),
+      v.literal("bonus"),
+      v.literal("expiry")
+    ),
+    bidCount: v.number(),
+    amount: v.number(),
+    paymentMethod: v.optional(v.string()),
+    paymentStatus: v.union(
+      v.literal("pending"),
+      v.literal("completed"),
+      v.literal("failed"),
+      v.literal("refunded")
+    ),
+    stripeSessionId: v.optional(v.string()),
+    description: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("bidTransactions", args);
+  },
+});
+
+// Migrate auto-bid config
+export const migrateAutoBidConfig = internalMutation({
+  args: {
+    userId: v.id("users"),
+    pennyAuctionId: v.id("pennyAuctions"),
+    maxBids: v.number(),
+    bidsUsed: v.number(),
+    isActive: v.boolean(),
+    stopWhenOutbid: v.boolean(),
+    bidDelaySec: v.number(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("autoBidConfigs", args);
+  },
+});
+
+// Get migration statistics
+export const getAuctionMigrationStats = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const auctions = await ctx.db.query("auctions").collect();
+    const bids = await ctx.db.query("bids").collect();
+    const pennyAuctions = await ctx.db.query("pennyAuctions").collect();
+    const pennyBids = await ctx.db.query("pennyBids").collect();
+    const bidPackages = await ctx.db.query("bidPackages").collect();
+    const userBalances = await ctx.db.query("userBidBalances").collect();
+    const transactions = await ctx.db.query("bidTransactions").collect();
+
+    return {
+      auctions: auctions.length,
+      bids: bids.length,
+      pennyAuctions: pennyAuctions.length,
+      pennyBids: pennyBids.length,
+      bidPackages: bidPackages.length,
+      userBalances: userBalances.length,
+      transactions: transactions.length,
+    };
+  },
+});

--- a/convex/auctions.ts
+++ b/convex/auctions.ts
@@ -1,0 +1,449 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAuth, requireSeller, requireAdmin } from "./_helpers/auth";
+
+/**
+ * Traditional Auction Functions
+ *
+ * Handles ascending bid auctions where the highest bidder wins when time expires.
+ */
+
+// ============================================
+// QUERIES
+// ============================================
+
+// Get all active auctions
+export const getActiveAuctions = query({
+  args: {
+    categoryId: v.optional(v.id("categories")),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    let query = ctx.db
+      .query("auctions")
+      .withIndex("by_status", (q) => q.eq("status", "active"));
+
+    const auctions = await query.collect();
+
+    // Filter by category if provided
+    let filtered = auctions.filter(
+      (a) => !a.isDisabled && a.endTime > now
+    );
+
+    if (args.categoryId) {
+      filtered = filtered.filter((a) => a.categoryId === args.categoryId);
+    }
+
+    // Sort by end time (ending soonest first)
+    filtered.sort((a, b) => a.endTime - b.endTime);
+
+    // Apply limit
+    if (args.limit) {
+      filtered = filtered.slice(0, args.limit);
+    }
+
+    // Get seller info for each auction
+    return Promise.all(
+      filtered.map(async (auction) => {
+        const seller = await ctx.db.get(auction.sellerId);
+        const category = await ctx.db.get(auction.categoryId);
+        return {
+          ...auction,
+          sellerName: seller?.name || "Unknown",
+          categoryName: category?.name || "Unknown",
+          timeRemaining: auction.endTime - now,
+        };
+      })
+    );
+  },
+});
+
+// Get auction by ID
+export const getAuctionById = query({
+  args: { auctionId: v.id("auctions") },
+  handler: async (ctx, args) => {
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) return null;
+
+    const seller = await ctx.db.get(auction.sellerId);
+    const category = await ctx.db.get(auction.categoryId);
+    const highestBidder = auction.highestBidderId
+      ? await ctx.db.get(auction.highestBidderId)
+      : null;
+
+    // Get bid history
+    const bids = await ctx.db
+      .query("bids")
+      .withIndex("by_auction", (q) => q.eq("auctionId", args.auctionId))
+      .order("desc")
+      .take(10);
+
+    const bidsWithUsers = await Promise.all(
+      bids.map(async (bid) => {
+        const bidder = await ctx.db.get(bid.bidderId);
+        return {
+          ...bid,
+          bidderName: bidder?.name || "Anonymous",
+        };
+      })
+    );
+
+    return {
+      ...auction,
+      sellerName: seller?.name || "Unknown",
+      categoryName: category?.name || "Unknown",
+      highestBidderName: highestBidder?.name || null,
+      recentBids: bidsWithUsers,
+      timeRemaining: Math.max(0, auction.endTime - Date.now()),
+    };
+  },
+});
+
+// Get seller's auctions
+export const getSellerAuctions = query({
+  args: { sellerId: v.optional(v.id("users")) },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const sellerId = args.sellerId || (identity?.subject as any);
+
+    if (!sellerId) return [];
+
+    const auctions = await ctx.db
+      .query("auctions")
+      .withIndex("by_seller", (q) => q.eq("sellerId", sellerId))
+      .order("desc")
+      .collect();
+
+    return auctions;
+  },
+});
+
+// Get user's bids
+export const getUserBids = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+
+    const bids = await ctx.db
+      .query("bids")
+      .withIndex("by_bidder", (q) => q.eq("bidderId", userId))
+      .order("desc")
+      .take(50);
+
+    const bidsWithAuctions = await Promise.all(
+      bids.map(async (bid) => {
+        const auction = await ctx.db.get(bid.auctionId);
+        return {
+          ...bid,
+          auctionTitle: auction?.title || "Unknown",
+          auctionStatus: auction?.status || "unknown",
+          auctionEndTime: auction?.endTime,
+        };
+      })
+    );
+
+    return bidsWithAuctions;
+  },
+});
+
+// ============================================
+// MUTATIONS
+// ============================================
+
+// Create a new auction
+export const createAuction = mutation({
+  args: {
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    condition: v.optional(v.string()),
+    startingBid: v.number(),
+    startTime: v.number(),
+    endTime: v.number(),
+    imageUrl: v.optional(v.string()),
+    reservePrice: v.optional(v.number()),
+    buyNowPrice: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const sellerId = await requireSeller(ctx);
+
+    // Validate times
+    if (args.startTime >= args.endTime) {
+      throw new Error("End time must be after start time");
+    }
+
+    if (args.startingBid <= 0) {
+      throw new Error("Starting bid must be positive");
+    }
+
+    const auctionId = await ctx.db.insert("auctions", {
+      ...args,
+      sellerId,
+      currentBid: args.startingBid,
+      highestBidderId: undefined,
+      status: args.startTime <= Date.now() ? "active" : "pending",
+      isDisabled: false,
+    });
+
+    return auctionId;
+  },
+});
+
+// Place a bid
+export const placeBid = mutation({
+  args: {
+    auctionId: v.id("auctions"),
+    amount: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const bidderId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) {
+      throw new Error("Auction not found");
+    }
+
+    if (auction.status !== "active") {
+      throw new Error("Auction is not active");
+    }
+
+    if (auction.endTime < Date.now()) {
+      throw new Error("Auction has ended");
+    }
+
+    if (auction.sellerId === bidderId) {
+      throw new Error("Cannot bid on your own auction");
+    }
+
+    if (args.amount <= auction.currentBid) {
+      throw new Error(`Bid must be higher than current bid of $${auction.currentBid}`);
+    }
+
+    // Mark previous winning bid as not winning
+    if (auction.highestBidderId) {
+      const previousBids = await ctx.db
+        .query("bids")
+        .withIndex("by_auction", (q) => q.eq("auctionId", args.auctionId))
+        .filter((q) => q.eq(q.field("isWinning"), true))
+        .collect();
+
+      for (const bid of previousBids) {
+        await ctx.db.patch(bid._id, { isWinning: false });
+      }
+    }
+
+    // Create the new bid
+    const bidId = await ctx.db.insert("bids", {
+      auctionId: args.auctionId,
+      bidderId,
+      amount: args.amount,
+      isWinning: true,
+    });
+
+    // Update auction
+    await ctx.db.patch(args.auctionId, {
+      currentBid: args.amount,
+      highestBidderId: bidderId,
+    });
+
+    // Notify previous bidder
+    if (auction.highestBidderId && auction.highestBidderId !== bidderId) {
+      await ctx.db.insert("notifications", {
+        userId: auction.highestBidderId,
+        title: "Outbid!",
+        message: `You've been outbid on "${auction.title}". Current bid: $${args.amount}`,
+        type: "auction",
+        isRead: false,
+        actionLink: `/auctions/${args.auctionId}`,
+      });
+    }
+
+    return bidId;
+  },
+});
+
+// Buy now (instant purchase)
+export const buyNow = mutation({
+  args: { auctionId: v.id("auctions") },
+  handler: async (ctx, args) => {
+    const buyerId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) {
+      throw new Error("Auction not found");
+    }
+
+    if (!auction.buyNowPrice) {
+      throw new Error("Buy now is not available for this auction");
+    }
+
+    if (auction.status !== "active") {
+      throw new Error("Auction is not active");
+    }
+
+    if (auction.sellerId === buyerId) {
+      throw new Error("Cannot buy your own auction");
+    }
+
+    // End the auction
+    await ctx.db.patch(args.auctionId, {
+      status: "completed",
+      highestBidderId: buyerId,
+      currentBid: auction.buyNowPrice,
+    });
+
+    // Create a "bid" record for the buy now
+    await ctx.db.insert("bids", {
+      auctionId: args.auctionId,
+      bidderId: buyerId,
+      amount: auction.buyNowPrice,
+      isWinning: true,
+    });
+
+    // Notify seller
+    await ctx.db.insert("notifications", {
+      userId: auction.sellerId,
+      title: "Auction Sold!",
+      message: `Your auction "${auction.title}" was purchased via Buy Now for $${auction.buyNowPrice}`,
+      type: "auction",
+      isRead: false,
+      actionLink: `/auctions/${args.auctionId}`,
+    });
+
+    return { success: true, finalPrice: auction.buyNowPrice };
+  },
+});
+
+// Update auction (seller only)
+export const updateAuction = mutation({
+  args: {
+    auctionId: v.id("auctions"),
+    title: v.optional(v.string()),
+    description: v.optional(v.string()),
+    imageUrl: v.optional(v.string()),
+    reservePrice: v.optional(v.number()),
+    buyNowPrice: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) {
+      throw new Error("Auction not found");
+    }
+
+    // Check ownership
+    const user = await ctx.db.get(userId);
+    if (auction.sellerId !== userId && user?.role !== "admin") {
+      throw new Error("Not authorized to update this auction");
+    }
+
+    // Can only update pending auctions or active ones with no bids
+    if (auction.status === "completed" || auction.status === "cancelled") {
+      throw new Error("Cannot update completed or cancelled auctions");
+    }
+
+    const updates: any = {};
+    if (args.title !== undefined) updates.title = args.title;
+    if (args.description !== undefined) updates.description = args.description;
+    if (args.imageUrl !== undefined) updates.imageUrl = args.imageUrl;
+    if (args.reservePrice !== undefined) updates.reservePrice = args.reservePrice;
+    if (args.buyNowPrice !== undefined) updates.buyNowPrice = args.buyNowPrice;
+
+    await ctx.db.patch(args.auctionId, updates);
+    return { success: true };
+  },
+});
+
+// Cancel auction (seller/admin)
+export const cancelAuction = mutation({
+  args: { auctionId: v.id("auctions") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) {
+      throw new Error("Auction not found");
+    }
+
+    const user = await ctx.db.get(userId);
+    if (auction.sellerId !== userId && user?.role !== "admin") {
+      throw new Error("Not authorized to cancel this auction");
+    }
+
+    if (auction.status === "completed") {
+      throw new Error("Cannot cancel completed auction");
+    }
+
+    await ctx.db.patch(args.auctionId, { status: "cancelled" });
+
+    // Notify highest bidder if any
+    if (auction.highestBidderId) {
+      await ctx.db.insert("notifications", {
+        userId: auction.highestBidderId,
+        title: "Auction Cancelled",
+        message: `The auction "${auction.title}" has been cancelled.`,
+        type: "auction",
+        isRead: false,
+      });
+    }
+
+    return { success: true };
+  },
+});
+
+// Complete auction (internal/scheduled)
+export const completeAuction = mutation({
+  args: { auctionId: v.id("auctions") },
+  handler: async (ctx, args) => {
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction || auction.status !== "active") {
+      return { success: false, reason: "Auction not active" };
+    }
+
+    if (auction.endTime > Date.now()) {
+      return { success: false, reason: "Auction has not ended yet" };
+    }
+
+    // Check if reserve price was met
+    const reserveMet = !auction.reservePrice || auction.currentBid >= auction.reservePrice;
+
+    await ctx.db.patch(args.auctionId, {
+      status: "completed",
+    });
+
+    // Notify winner and seller
+    if (auction.highestBidderId && reserveMet) {
+      await ctx.db.insert("notifications", {
+        userId: auction.highestBidderId,
+        title: "You Won!",
+        message: `Congratulations! You won "${auction.title}" for $${auction.currentBid}`,
+        type: "auction",
+        isRead: false,
+        actionLink: `/auctions/${args.auctionId}`,
+      });
+
+      await ctx.db.insert("notifications", {
+        userId: auction.sellerId,
+        title: "Auction Sold!",
+        message: `Your auction "${auction.title}" sold for $${auction.currentBid}`,
+        type: "auction",
+        isRead: false,
+        actionLink: `/auctions/${args.auctionId}`,
+      });
+    } else {
+      // No winner or reserve not met
+      await ctx.db.insert("notifications", {
+        userId: auction.sellerId,
+        title: "Auction Ended",
+        message: `Your auction "${auction.title}" ended ${reserveMet ? "with no bids" : "without meeting reserve"}`,
+        type: "auction",
+        isRead: false,
+        actionLink: `/auctions/${args.auctionId}`,
+      });
+    }
+
+    return { success: true, winner: auction.highestBidderId, finalPrice: auction.currentBid };
+  },
+});

--- a/convex/bidPackages.ts
+++ b/convex/bidPackages.ts
@@ -1,0 +1,355 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAuth, requireAdmin } from "./_helpers/auth";
+
+/**
+ * Bid Package Functions
+ *
+ * Handles purchasable bid packages for penny auctions.
+ * Users buy bid packages to get bids they can use in penny auctions.
+ */
+
+// ============================================
+// QUERIES
+// ============================================
+
+// Get all active bid packages
+export const getBidPackages = query({
+  args: { featuredOnly: v.optional(v.boolean()) },
+  handler: async (ctx, args) => {
+    let packages = await ctx.db
+      .query("bidPackages")
+      .withIndex("by_active", (q) => q.eq("isActive", true))
+      .collect();
+
+    if (args.featuredOnly) {
+      packages = packages.filter((p) => p.featured);
+    }
+
+    // Sort by price
+    packages.sort((a, b) => a.price - b.price);
+
+    // Calculate value per bid
+    return packages.map((pkg) => ({
+      ...pkg,
+      pricePerBid: (pkg.price / pkg.bidCount).toFixed(2),
+      savings: pkg.discountPercentage > 0
+        ? `${pkg.discountPercentage}% off`
+        : null,
+    }));
+  },
+});
+
+// Get user's bid balance
+export const getUserBidBalance = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+
+    const balance = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .first();
+
+    if (!balance) {
+      return {
+        bidBalance: 0,
+        totalBidsPurchased: 0,
+        totalBidsUsed: 0,
+        lastPurchaseDate: null,
+      };
+    }
+
+    return balance;
+  },
+});
+
+// Get user's transaction history
+export const getUserTransactions = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const transactions = await ctx.db
+      .query("bidTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .order("desc")
+      .take(args.limit || 50);
+
+    return transactions;
+  },
+});
+
+// ============================================
+// MUTATIONS
+// ============================================
+
+// Purchase a bid package (creates pending transaction)
+export const initiatePurchase = mutation({
+  args: { packageId: v.id("bidPackages") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg || !pkg.isActive) {
+      throw new Error("Bid package not available");
+    }
+
+    // Create pending transaction
+    const transactionId = await ctx.db.insert("bidTransactions", {
+      userId,
+      bidPackageId: args.packageId,
+      transactionType: "purchase",
+      bidCount: pkg.bidCount,
+      amount: pkg.price,
+      paymentStatus: "pending",
+      description: `Purchase of ${pkg.name} (${pkg.bidCount} bids)`,
+    });
+
+    // Return transaction ID for Stripe checkout
+    return {
+      transactionId,
+      packageName: pkg.name,
+      bidCount: pkg.bidCount,
+      amount: pkg.price,
+    };
+  },
+});
+
+// Complete purchase (called after Stripe webhook)
+export const completePurchase = mutation({
+  args: {
+    transactionId: v.id("bidTransactions"),
+    stripeSessionId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const transaction = await ctx.db.get(args.transactionId);
+    if (!transaction) {
+      throw new Error("Transaction not found");
+    }
+
+    if (transaction.paymentStatus !== "pending") {
+      throw new Error("Transaction already processed");
+    }
+
+    // Update transaction
+    await ctx.db.patch(args.transactionId, {
+      paymentStatus: "completed",
+      stripeSessionId: args.stripeSessionId,
+    });
+
+    // Update or create user bid balance
+    const existingBalance = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", transaction.userId))
+      .first();
+
+    if (existingBalance) {
+      await ctx.db.patch(existingBalance._id, {
+        bidBalance: existingBalance.bidBalance + transaction.bidCount,
+        totalBidsPurchased: existingBalance.totalBidsPurchased + transaction.bidCount,
+        lastPurchaseDate: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("userBidBalances", {
+        userId: transaction.userId,
+        bidBalance: transaction.bidCount,
+        totalBidsPurchased: transaction.bidCount,
+        totalBidsUsed: 0,
+        lastPurchaseDate: Date.now(),
+      });
+    }
+
+    // Create notification
+    await ctx.db.insert("notifications", {
+      userId: transaction.userId,
+      title: "Bids Added!",
+      message: `${transaction.bidCount} bids have been added to your account.`,
+      type: "payment",
+      isRead: false,
+    });
+
+    return { success: true, bidsAdded: transaction.bidCount };
+  },
+});
+
+// Refund purchase
+export const refundPurchase = mutation({
+  args: { transactionId: v.id("bidTransactions") },
+  handler: async (ctx, args) => {
+    const adminId = await requireAdmin(ctx);
+
+    const transaction = await ctx.db.get(args.transactionId);
+    if (!transaction) {
+      throw new Error("Transaction not found");
+    }
+
+    if (transaction.paymentStatus !== "completed") {
+      throw new Error("Can only refund completed transactions");
+    }
+
+    // Check if user has enough bids to refund
+    const balance = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", transaction.userId))
+      .first();
+
+    if (!balance || balance.bidBalance < transaction.bidCount) {
+      throw new Error("User has already used some of these bids");
+    }
+
+    // Update transaction
+    await ctx.db.patch(args.transactionId, {
+      paymentStatus: "refunded",
+    });
+
+    // Deduct bids from balance
+    await ctx.db.patch(balance._id, {
+      bidBalance: balance.bidBalance - transaction.bidCount,
+      totalBidsPurchased: balance.totalBidsPurchased - transaction.bidCount,
+    });
+
+    // Create refund transaction record
+    await ctx.db.insert("bidTransactions", {
+      userId: transaction.userId,
+      bidPackageId: transaction.bidPackageId,
+      transactionType: "refund",
+      bidCount: -transaction.bidCount,
+      amount: -transaction.amount,
+      paymentStatus: "completed",
+      description: `Refund of ${transaction.bidCount} bids`,
+    });
+
+    // Notify user
+    await ctx.db.insert("notifications", {
+      userId: transaction.userId,
+      title: "Purchase Refunded",
+      message: `Your purchase of ${transaction.bidCount} bids has been refunded.`,
+      type: "payment",
+      isRead: false,
+    });
+
+    return { success: true };
+  },
+});
+
+// Add bonus bids (admin)
+export const addBonusBids = mutation({
+  args: {
+    userId: v.id("users"),
+    bidCount: v.number(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    // Update or create balance
+    const existingBalance = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .first();
+
+    if (existingBalance) {
+      await ctx.db.patch(existingBalance._id, {
+        bidBalance: existingBalance.bidBalance + args.bidCount,
+        totalBidsPurchased: existingBalance.totalBidsPurchased + args.bidCount,
+      });
+    } else {
+      await ctx.db.insert("userBidBalances", {
+        userId: args.userId,
+        bidBalance: args.bidCount,
+        totalBidsPurchased: args.bidCount,
+        totalBidsUsed: 0,
+      });
+    }
+
+    // Record transaction
+    await ctx.db.insert("bidTransactions", {
+      userId: args.userId,
+      transactionType: "bonus",
+      bidCount: args.bidCount,
+      amount: 0,
+      paymentStatus: "completed",
+      description: `Bonus: ${args.reason}`,
+    });
+
+    // Notify user
+    await ctx.db.insert("notifications", {
+      userId: args.userId,
+      title: "Bonus Bids!",
+      message: `You received ${args.bidCount} bonus bids: ${args.reason}`,
+      type: "payment",
+      isRead: false,
+    });
+
+    return { success: true };
+  },
+});
+
+// ============================================
+// ADMIN MUTATIONS
+// ============================================
+
+// Create bid package
+export const createBidPackage = mutation({
+  args: {
+    name: v.string(),
+    description: v.optional(v.string()),
+    bidCount: v.number(),
+    price: v.number(),
+    discountPercentage: v.optional(v.number()),
+    imageUrl: v.optional(v.string()),
+    featured: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    return await ctx.db.insert("bidPackages", {
+      name: args.name,
+      description: args.description,
+      bidCount: args.bidCount,
+      price: args.price,
+      isActive: true,
+      discountPercentage: args.discountPercentage ?? 0,
+      imageUrl: args.imageUrl,
+      featured: args.featured ?? false,
+    });
+  },
+});
+
+// Update bid package
+export const updateBidPackage = mutation({
+  args: {
+    packageId: v.id("bidPackages"),
+    name: v.optional(v.string()),
+    description: v.optional(v.string()),
+    bidCount: v.optional(v.number()),
+    price: v.optional(v.number()),
+    isActive: v.optional(v.boolean()),
+    discountPercentage: v.optional(v.number()),
+    featured: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    const { packageId, ...updates } = args;
+    const filteredUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([, v]) => v !== undefined)
+    );
+
+    await ctx.db.patch(packageId, filteredUpdates);
+    return { success: true };
+  },
+});
+
+// Delete bid package
+export const deleteBidPackage = mutation({
+  args: { packageId: v.id("bidPackages") },
+  handler: async (ctx, args) => {
+    await requireAdmin(ctx);
+
+    // Soft delete by deactivating
+    await ctx.db.patch(args.packageId, { isActive: false });
+    return { success: true };
+  },
+});

--- a/convex/pennyAuctions.ts
+++ b/convex/pennyAuctions.ts
@@ -1,0 +1,409 @@
+import { mutation, query, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { requireAuth, requireSeller, requireAdmin } from "./_helpers/auth";
+
+/**
+ * Penny Auction Functions
+ *
+ * Timer-based auctions where each bid:
+ * - Costs the bidder a bid from their balance
+ * - Increases the price by a small increment (e.g., $0.01)
+ * - Extends the timer by a few seconds
+ * - Makes the bidder the current winner
+ */
+
+// ============================================
+// QUERIES
+// ============================================
+
+// Get active penny auctions
+export const getActivePennyAuctions = query({
+  args: {
+    categoryId: v.optional(v.id("categories")),
+    featured: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    let auctions = await ctx.db
+      .query("pennyAuctions")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .collect();
+
+    // Filter
+    auctions = auctions.filter((a) => !a.isDisabled && a.endTime > now);
+
+    if (args.categoryId) {
+      auctions = auctions.filter((a) => a.categoryId === args.categoryId);
+    }
+
+    if (args.featured !== undefined) {
+      auctions = auctions.filter((a) => a.featured === args.featured);
+    }
+
+    // Sort by end time
+    auctions.sort((a, b) => a.endTime - b.endTime);
+
+    if (args.limit) {
+      auctions = auctions.slice(0, args.limit);
+    }
+
+    // Enrich with additional data
+    return Promise.all(
+      auctions.map(async (auction) => {
+        const category = await ctx.db.get(auction.categoryId);
+        const highestBidder = auction.highestBidderId
+          ? await ctx.db.get(auction.highestBidderId)
+          : null;
+
+        return {
+          ...auction,
+          categoryName: category?.name || "Unknown",
+          highestBidderName: highestBidder?.name || null,
+          timeRemaining: Math.max(0, auction.endTime - now),
+          savings: auction.retailPrice - auction.currentPrice,
+          savingsPercent: Math.round(
+            ((auction.retailPrice - auction.currentPrice) / auction.retailPrice) * 100
+          ),
+        };
+      })
+    );
+  },
+});
+
+// Get penny auction by ID
+export const getPennyAuctionById = query({
+  args: { auctionId: v.id("pennyAuctions") },
+  handler: async (ctx, args) => {
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) return null;
+
+    const category = await ctx.db.get(auction.categoryId);
+    const seller = await ctx.db.get(auction.sellerId);
+    const highestBidder = auction.highestBidderId
+      ? await ctx.db.get(auction.highestBidderId)
+      : null;
+
+    // Get recent bids
+    const recentBids = await ctx.db
+      .query("pennyBids")
+      .withIndex("by_auction", (q) => q.eq("pennyAuctionId", args.auctionId))
+      .order("desc")
+      .take(20);
+
+    const bidsWithUsers = await Promise.all(
+      recentBids.map(async (bid) => {
+        const bidder = await ctx.db.get(bid.bidderId);
+        return {
+          ...bid,
+          bidderName: bidder?.name || "Anonymous",
+        };
+      })
+    );
+
+    const now = Date.now();
+
+    return {
+      ...auction,
+      categoryName: category?.name || "Unknown",
+      sellerName: seller?.name || "Unknown",
+      highestBidderName: highestBidder?.name || null,
+      recentBids: bidsWithUsers,
+      timeRemaining: Math.max(0, auction.endTime - now),
+      savings: auction.retailPrice - auction.currentPrice,
+    };
+  },
+});
+
+// Get user's penny auction activity
+export const getUserPennyActivity = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireAuth(ctx);
+
+    // Get user's bids
+    const bids = await ctx.db
+      .query("pennyBids")
+      .withIndex("by_bidder", (q) => q.eq("bidderId", userId))
+      .order("desc")
+      .take(100);
+
+    // Get unique auctions
+    const auctionIds = [...new Set(bids.map((b) => b.pennyAuctionId))];
+    const auctions = await Promise.all(
+      auctionIds.map((id) => ctx.db.get(id))
+    );
+
+    // Get user's auto-bid configs
+    const autoBids = await ctx.db
+      .query("autoBidConfigs")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+
+    return {
+      totalBidsPlaced: bids.length,
+      auctionsParticipated: auctionIds.length,
+      recentBids: bids.slice(0, 20),
+      activeAutoBids: autoBids.filter((a) => a.isActive),
+      wonAuctions: auctions.filter((a) => a?.winnerId === userId),
+    };
+  },
+});
+
+// ============================================
+// MUTATIONS
+// ============================================
+
+// Place a penny bid
+export const placePennyBid = mutation({
+  args: {
+    auctionId: v.id("pennyAuctions"),
+    isAutoBid: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const bidderId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction) {
+      throw new Error("Auction not found");
+    }
+
+    if (auction.status !== "active") {
+      throw new Error("Auction is not active");
+    }
+
+    const now = Date.now();
+    if (auction.endTime < now) {
+      throw new Error("Auction has ended");
+    }
+
+    if (auction.sellerId === bidderId) {
+      throw new Error("Cannot bid on your own auction");
+    }
+
+    // Check user's bid balance
+    const bidBalance = await ctx.db
+      .query("userBidBalances")
+      .withIndex("by_user", (q) => q.eq("userId", bidderId))
+      .first();
+
+    if (!bidBalance || bidBalance.bidBalance < 1) {
+      throw new Error("Insufficient bid balance. Please purchase more bids.");
+    }
+
+    // Deduct bid from balance
+    await ctx.db.patch(bidBalance._id, {
+      bidBalance: bidBalance.bidBalance - 1,
+      totalBidsUsed: bidBalance.totalBidsUsed + 1,
+    });
+
+    // Record the bid transaction
+    await ctx.db.insert("bidTransactions", {
+      userId: bidderId,
+      transactionType: "use",
+      bidCount: -1,
+      amount: 0,
+      paymentStatus: "completed",
+      description: `Bid placed on "${auction.title}"`,
+    });
+
+    // Calculate new price and end time
+    const newPrice = auction.currentPrice + auction.bidIncrement;
+    const newEndTime = Math.max(auction.endTime, now + auction.timerSeconds * 1000);
+
+    // Create the bid record
+    const bidId = await ctx.db.insert("pennyBids", {
+      pennyAuctionId: args.auctionId,
+      bidderId,
+      bidAmount: auction.bidIncrement,
+      bidCost: auction.bidCost,
+      newPrice,
+      timerExtended: newEndTime > auction.endTime,
+      isAutoBid: args.isAutoBid || false,
+    });
+
+    // Update auction
+    await ctx.db.patch(args.auctionId, {
+      currentPrice: newPrice,
+      endTime: newEndTime,
+      highestBidderId: bidderId,
+      totalBids: auction.totalBids + 1,
+    });
+
+    // Notify previous bidder if different
+    if (auction.highestBidderId && auction.highestBidderId !== bidderId) {
+      await ctx.db.insert("notifications", {
+        userId: auction.highestBidderId,
+        title: "Outbid!",
+        message: `You've been outbid on "${auction.title}". Price: $${newPrice.toFixed(2)}`,
+        type: "bid",
+        isRead: false,
+        actionLink: `/penny-auctions/${args.auctionId}`,
+      });
+    }
+
+    return {
+      bidId,
+      newPrice,
+      newEndTime,
+      timeRemaining: newEndTime - now,
+    };
+  },
+});
+
+// Set up auto-bid
+export const setupAutoBid = mutation({
+  args: {
+    auctionId: v.id("pennyAuctions"),
+    maxBids: v.number(),
+    stopWhenOutbid: v.optional(v.boolean()),
+    bidDelaySec: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction || auction.status !== "active") {
+      throw new Error("Auction not active");
+    }
+
+    // Check existing config
+    const existing = await ctx.db
+      .query("autoBidConfigs")
+      .withIndex("by_user_and_auction", (q) =>
+        q.eq("userId", userId).eq("pennyAuctionId", args.auctionId)
+      )
+      .first();
+
+    if (existing) {
+      // Update existing
+      await ctx.db.patch(existing._id, {
+        maxBids: args.maxBids,
+        stopWhenOutbid: args.stopWhenOutbid ?? false,
+        bidDelaySec: args.bidDelaySec ?? 1,
+        isActive: true,
+      });
+      return existing._id;
+    }
+
+    // Create new config
+    return await ctx.db.insert("autoBidConfigs", {
+      userId,
+      pennyAuctionId: args.auctionId,
+      maxBids: args.maxBids,
+      bidsUsed: 0,
+      isActive: true,
+      stopWhenOutbid: args.stopWhenOutbid ?? false,
+      bidDelaySec: args.bidDelaySec ?? 1,
+    });
+  },
+});
+
+// Cancel auto-bid
+export const cancelAutoBid = mutation({
+  args: { auctionId: v.id("pennyAuctions") },
+  handler: async (ctx, args) => {
+    const userId = await requireAuth(ctx);
+
+    const config = await ctx.db
+      .query("autoBidConfigs")
+      .withIndex("by_user_and_auction", (q) =>
+        q.eq("userId", userId).eq("pennyAuctionId", args.auctionId)
+      )
+      .first();
+
+    if (config) {
+      await ctx.db.patch(config._id, { isActive: false });
+    }
+
+    return { success: true };
+  },
+});
+
+// Create penny auction (seller)
+export const createPennyAuction = mutation({
+  args: {
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    imageUrl: v.optional(v.string()),
+    retailPrice: v.number(),
+    bidIncrement: v.optional(v.number()),
+    bidCost: v.optional(v.number()),
+    startTime: v.number(),
+    durationSeconds: v.number(),
+    timerSeconds: v.optional(v.number()),
+    featured: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const sellerId = await requireSeller(ctx);
+
+    const auctionId = await ctx.db.insert("pennyAuctions", {
+      title: args.title,
+      description: args.description,
+      categoryId: args.categoryId,
+      imageUrl: args.imageUrl,
+      retailPrice: args.retailPrice,
+      startingPrice: 0,
+      currentPrice: 0,
+      bidIncrement: args.bidIncrement ?? 0.01,
+      bidCost: args.bidCost ?? 0.5,
+      startTime: args.startTime,
+      endTime: args.startTime + args.durationSeconds * 1000,
+      timerSeconds: args.timerSeconds ?? 10,
+      status: args.startTime <= Date.now() ? "active" : "pending",
+      highestBidderId: undefined,
+      totalBids: 0,
+      isDisabled: false,
+      sellerId,
+      featured: args.featured ?? false,
+    });
+
+    return auctionId;
+  },
+});
+
+// Complete penny auction (internal)
+export const completePennyAuction = internalMutation({
+  args: { auctionId: v.id("pennyAuctions") },
+  handler: async (ctx, args) => {
+    const auction = await ctx.db.get(args.auctionId);
+    if (!auction || auction.status !== "active") {
+      return { success: false };
+    }
+
+    if (auction.endTime > Date.now()) {
+      return { success: false, reason: "Not ended yet" };
+    }
+
+    await ctx.db.patch(args.auctionId, {
+      status: "completed",
+      winnerId: auction.highestBidderId,
+      finalPrice: auction.currentPrice,
+    });
+
+    // Notify winner
+    if (auction.highestBidderId) {
+      await ctx.db.insert("notifications", {
+        userId: auction.highestBidderId,
+        title: "You Won!",
+        message: `Congratulations! You won "${auction.title}" for only $${auction.currentPrice.toFixed(2)} (retail: $${auction.retailPrice})!`,
+        type: "auction",
+        isRead: false,
+        actionLink: `/penny-auctions/${args.auctionId}`,
+      });
+    }
+
+    // Notify seller
+    await ctx.db.insert("notifications", {
+      userId: auction.sellerId,
+      title: "Auction Completed",
+      message: `Your penny auction "${auction.title}" has ended with ${auction.totalBids} bids.`,
+      type: "auction",
+      isRead: false,
+    });
+
+    return { success: true, winnerId: auction.highestBidderId };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3,12 +3,21 @@ import { v } from "convex/values";
 
 /**
  * Convex Schema for Multi-Vendor Marketplace
- * 
+ *
  * This schema defines all database tables for the marketplace application.
- * Migrated from PostgreSQL/Sequelize models to Convex.
+ * Includes:
+ * - Core e-commerce (users, products, orders, carts, reviews)
+ * - Traditional auctions
+ * - Penny auctions with bid packages
+ * - Digital products and services
+ * - Minute-based service billing
  */
 
 export default defineSchema({
+  // ============================================
+  // CORE E-COMMERCE TABLES
+  // ============================================
+
   // Users table - migrated from User model
   users: defineTable({
     name: v.string(),
@@ -26,8 +35,7 @@ export default defineSchema({
   categories: defineTable({
     name: v.string(),
     description: v.optional(v.string()),
-  })
-    .index("by_name", ["name"]),
+  }).index("by_name", ["name"]),
 
   // Products table - migrated from Product model
   products: defineTable({
@@ -51,6 +59,7 @@ export default defineSchema({
     status: v.string(), // 'pending', 'processing', 'shipped', 'delivered', 'cancelled'
     shippingAddress: v.optional(v.string()),
     paymentStatus: v.string(), // 'unpaid', 'paid', 'refunded'
+    stripeSessionId: v.optional(v.string()),
   })
     .index("by_user", ["userId"])
     .index("by_status", ["status"])
@@ -71,8 +80,7 @@ export default defineSchema({
   // Carts table - migrated from Cart model
   carts: defineTable({
     userId: v.id("users"),
-  })
-    .index("by_user", ["userId"]),
+  }).index("by_user", ["userId"]),
 
   // CartItems table - migrated from CartItem model
   cartItems: defineTable({
@@ -110,4 +118,355 @@ export default defineSchema({
     .index("by_read_status", ["isRead"])
     .index("by_type", ["type"])
     .index("by_user_and_read", ["userId", "isRead"]),
+
+  // ============================================
+  // TRADITIONAL AUCTION TABLES
+  // ============================================
+
+  // Auctions table - traditional ascending bid auctions
+  auctions: defineTable({
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    condition: v.optional(v.string()), // 'new', 'like_new', 'good', 'fair'
+    startingBid: v.number(),
+    currentBid: v.number(),
+    startTime: v.number(), // Timestamp
+    endTime: v.number(), // Timestamp
+    imageUrl: v.optional(v.string()),
+    sellerId: v.id("users"),
+    highestBidderId: v.optional(v.id("users")),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("completed"),
+      v.literal("cancelled")
+    ),
+    isDisabled: v.boolean(),
+    reservePrice: v.optional(v.number()), // Minimum price to sell
+    buyNowPrice: v.optional(v.number()), // Instant purchase price
+  })
+    .index("by_category", ["categoryId"])
+    .index("by_seller", ["sellerId"])
+    .index("by_status", ["status"])
+    .index("by_end_time", ["endTime"])
+    .index("by_start_time", ["startTime"])
+    .index("by_status_and_end_time", ["status", "endTime"]),
+
+  // Bids table - bids on traditional auctions
+  bids: defineTable({
+    auctionId: v.id("auctions"),
+    bidderId: v.id("users"),
+    amount: v.number(),
+    isWinning: v.boolean(),
+  })
+    .index("by_auction", ["auctionId"])
+    .index("by_bidder", ["bidderId"])
+    .index("by_auction_and_amount", ["auctionId", "amount"]),
+
+  // ============================================
+  // PENNY AUCTION TABLES
+  // ============================================
+
+  // Penny Auctions - timer-based auctions with paid bids
+  pennyAuctions: defineTable({
+    title: v.string(),
+    description: v.optional(v.string()),
+    categoryId: v.id("categories"),
+    imageUrl: v.optional(v.string()),
+    retailPrice: v.number(), // Original product value
+    startingPrice: v.number(), // Usually $0
+    currentPrice: v.number(), // Current price (increments with each bid)
+    bidIncrement: v.number(), // Price increase per bid (default $0.01)
+    bidCost: v.number(), // Cost to place a bid (default $0.50)
+    startTime: v.number(),
+    endTime: v.number(), // Current end time (extends with each bid)
+    timerSeconds: v.number(), // Seconds added per bid (default 10)
+    status: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("completed"),
+      v.literal("cancelled")
+    ),
+    highestBidderId: v.optional(v.id("users")),
+    totalBids: v.number(),
+    isDisabled: v.boolean(),
+    sellerId: v.id("users"),
+    featured: v.boolean(),
+    winnerId: v.optional(v.id("users")),
+    finalPrice: v.optional(v.number()),
+  })
+    .index("by_category", ["categoryId"])
+    .index("by_seller", ["sellerId"])
+    .index("by_status", ["status"])
+    .index("by_end_time", ["endTime"])
+    .index("by_featured", ["featured"])
+    .index("by_status_and_featured", ["status", "featured"]),
+
+  // Penny Bids - individual bids on penny auctions
+  pennyBids: defineTable({
+    pennyAuctionId: v.id("pennyAuctions"),
+    bidderId: v.id("users"),
+    bidAmount: v.number(), // Always bidIncrement (e.g., $0.01)
+    bidCost: v.number(), // Cost deducted from user's bid balance
+    newPrice: v.number(), // Price after this bid
+    timerExtended: v.boolean(), // Whether timer was extended
+    isAutoBid: v.boolean(), // Whether this was an auto-bid
+  })
+    .index("by_auction", ["pennyAuctionId"])
+    .index("by_bidder", ["bidderId"])
+    .index("by_auction_and_time", ["pennyAuctionId"]),
+
+  // Bid Packages - purchasable bid packs
+  bidPackages: defineTable({
+    name: v.string(),
+    description: v.optional(v.string()),
+    bidCount: v.number(), // Number of bids in package
+    price: v.number(), // USD price
+    isActive: v.boolean(),
+    discountPercentage: v.number(), // Discount from regular price
+    imageUrl: v.optional(v.string()),
+    featured: v.boolean(),
+  })
+    .index("by_active", ["isActive"])
+    .index("by_featured", ["featured"]),
+
+  // User Bid Balances - tracks user's available bids
+  userBidBalances: defineTable({
+    userId: v.id("users"),
+    bidBalance: v.number(), // Available bids
+    totalBidsPurchased: v.number(),
+    totalBidsUsed: v.number(),
+    lastPurchaseDate: v.optional(v.number()),
+  }).index("by_user", ["userId"]),
+
+  // Bid Transactions - purchase and usage history
+  bidTransactions: defineTable({
+    userId: v.id("users"),
+    bidPackageId: v.optional(v.id("bidPackages")),
+    transactionType: v.union(
+      v.literal("purchase"),
+      v.literal("use"),
+      v.literal("refund"),
+      v.literal("bonus"),
+      v.literal("expiry")
+    ),
+    bidCount: v.number(), // Positive for purchases, negative for usage
+    amount: v.number(), // USD amount (for purchases)
+    paymentMethod: v.optional(v.string()),
+    paymentStatus: v.union(
+      v.literal("pending"),
+      v.literal("completed"),
+      v.literal("failed"),
+      v.literal("refunded")
+    ),
+    stripeSessionId: v.optional(v.string()),
+    description: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_package", ["bidPackageId"])
+    .index("by_type", ["transactionType"])
+    .index("by_status", ["paymentStatus"]),
+
+  // Auto Bid Config - automated bidding settings
+  autoBidConfigs: defineTable({
+    userId: v.id("users"),
+    pennyAuctionId: v.id("pennyAuctions"),
+    maxBids: v.number(), // Maximum bids to place
+    bidsUsed: v.number(), // Bids already placed
+    isActive: v.boolean(),
+    stopWhenOutbid: v.boolean(), // Stop if someone else bids
+    bidDelaySec: v.number(), // Delay between auto-bids
+  })
+    .index("by_user", ["userId"])
+    .index("by_auction", ["pennyAuctionId"])
+    .index("by_active", ["isActive"])
+    .index("by_user_and_auction", ["userId", "pennyAuctionId"]),
+
+  // ============================================
+  // DIGITAL PRODUCTS & SERVICES
+  // ============================================
+
+  // Digital Products - downloadable/access-based products
+  digitalProducts: defineTable({
+    title: v.string(),
+    description: v.optional(v.string()),
+    price: v.number(),
+    salePrice: v.optional(v.number()),
+    categoryId: v.id("categories"),
+    sellerId: v.id("users"),
+    fileUrl: v.optional(v.string()), // Stored file URL
+    fileKey: v.optional(v.string()), // Storage key
+    fileSize: v.optional(v.number()), // Bytes
+    fileType: v.optional(v.string()), // MIME type
+    previewUrl: v.optional(v.string()),
+    deliveryType: v.union(
+      v.literal("download"),
+      v.literal("access_key"),
+      v.literal("online_access")
+    ),
+    licenseType: v.union(
+      v.literal("single_user"),
+      v.literal("multi_user"),
+      v.literal("subscription")
+    ),
+    subscriptionPeriod: v.optional(
+      v.union(v.literal("monthly"), v.literal("yearly"))
+    ),
+    downloadLimit: v.optional(v.number()),
+    isWatermarked: v.boolean(),
+    status: v.union(v.literal("draft"), v.literal("active"), v.literal("inactive")),
+    tags: v.optional(v.array(v.string())),
+    averageRating: v.number(),
+    totalRatings: v.number(),
+    totalSales: v.number(),
+    allowAffiliates: v.boolean(),
+    affiliateCommissionRate: v.number(), // Percentage
+  })
+    .index("by_category", ["categoryId"])
+    .index("by_seller", ["sellerId"])
+    .index("by_status", ["status"])
+    .index("by_delivery_type", ["deliveryType"]),
+
+  // Digital Purchases - records of digital product purchases
+  digitalPurchases: defineTable({
+    productId: v.id("digitalProducts"),
+    buyerId: v.id("users"),
+    sellerId: v.id("users"),
+    amount: v.number(),
+    paymentId: v.optional(v.string()),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("completed"),
+      v.literal("refunded"),
+      v.literal("cancelled")
+    ),
+    accessDetails: v.optional(v.any()), // License keys, access URLs, etc.
+    accessExpiration: v.optional(v.number()),
+    downloadCount: v.number(),
+    lastDownloadDate: v.optional(v.number()),
+    affiliateId: v.optional(v.id("users")),
+    affiliateCommission: v.optional(v.number()),
+  })
+    .index("by_product", ["productId"])
+    .index("by_buyer", ["buyerId"])
+    .index("by_seller", ["sellerId"])
+    .index("by_status", ["status"]),
+
+  // ============================================
+  // MINUTE-BASED SERVICES
+  // ============================================
+
+  // Minute Services - time-based service offerings
+  minuteServices: defineTable({
+    title: v.string(),
+    description: v.optional(v.string()),
+    ratePerMinute: v.number(), // USD per minute
+    minimumMinutes: v.number(),
+    maximumMinutes: v.optional(v.number()),
+    maximumCharge: v.optional(v.number()), // Cap on total charge
+    categoryId: v.id("categories"),
+    providerId: v.id("users"), // Service provider
+    isActive: v.boolean(),
+    tags: v.optional(v.array(v.string())),
+    averageRating: v.number(),
+    totalRatings: v.number(),
+  })
+    .index("by_category", ["categoryId"])
+    .index("by_provider", ["providerId"])
+    .index("by_active", ["isActive"]),
+
+  // Service Sessions - active or completed service sessions
+  serviceSessions: defineTable({
+    serviceId: v.id("minuteServices"),
+    userId: v.id("users"), // Customer
+    providerId: v.id("users"), // Service provider
+    startTime: v.number(),
+    endTime: v.optional(v.number()),
+    durationMinutes: v.optional(v.number()),
+    amount: v.number(), // Total charge
+    status: v.union(
+      v.literal("active"),
+      v.literal("paused"),
+      v.literal("completed"),
+      v.literal("cancelled")
+    ),
+    paymentStatus: v.union(
+      v.literal("pending"),
+      v.literal("paid"),
+      v.literal("refunded"),
+      v.literal("disputed")
+    ),
+    paymentId: v.optional(v.string()),
+    notes: v.optional(v.string()),
+  })
+    .index("by_service", ["serviceId"])
+    .index("by_user", ["userId"])
+    .index("by_provider", ["providerId"])
+    .index("by_status", ["status"]),
+
+  // ============================================
+  // PLATFORM SERVICE USAGE & BILLING
+  // ============================================
+
+  // Service Usage - tracks platform service consumption
+  serviceUsage: defineTable({
+    userId: v.id("users"),
+    serviceType: v.union(
+      v.literal("auction"),
+      v.literal("marketplace"),
+      v.literal("premium_listing"),
+      v.literal("featured_product"),
+      v.literal("analytics"),
+      v.literal("api_access")
+    ),
+    startTime: v.number(),
+    endTime: v.optional(v.number()),
+    durationMinutes: v.optional(v.number()),
+    ratePerMinute: v.number(),
+    totalCost: v.number(),
+    status: v.union(
+      v.literal("active"),
+      v.literal("completed"),
+      v.literal("billed")
+    ),
+    description: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_type", ["serviceType"])
+    .index("by_status", ["status"]),
+
+  // Service Billing - periodic billing records
+  serviceBilling: defineTable({
+    userId: v.id("users"),
+    billingPeriodStart: v.number(),
+    billingPeriodEnd: v.number(),
+    totalAmount: v.number(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("paid"),
+      v.literal("overdue"),
+      v.literal("cancelled")
+    ),
+    dueDate: v.number(),
+    paymentDate: v.optional(v.number()),
+    paymentMethod: v.optional(v.string()),
+    invoiceNumber: v.string(),
+    notes: v.optional(v.string()),
+  })
+    .index("by_user", ["userId"])
+    .index("by_status", ["status"])
+    .index("by_invoice", ["invoiceNumber"]),
+
+  // Service Billing Items - line items in billing
+  serviceBillingItems: defineTable({
+    serviceBillingId: v.id("serviceBilling"),
+    serviceUsageId: v.id("serviceUsage"),
+    amount: v.number(),
+    description: v.optional(v.string()),
+  })
+    .index("by_billing", ["serviceBillingId"])
+    .index("by_usage", ["serviceUsageId"]),
 });

--- a/docs/EXTENDED_SCHEMA.md
+++ b/docs/EXTENDED_SCHEMA.md
@@ -1,0 +1,391 @@
+# Extended Convex Schema
+
+This document describes the extended schema for auctions, penny auctions, digital products, and services.
+
+## Schema Overview
+
+The extended schema adds 15 new tables to the base marketplace:
+
+| Table | Purpose |
+|-------|---------|
+| **auctions** | Traditional ascending bid auctions |
+| **bids** | Bids on traditional auctions |
+| **pennyAuctions** | Timer-based penny auctions |
+| **pennyBids** | Bids on penny auctions |
+| **bidPackages** | Purchasable bid packs |
+| **userBidBalances** | User's available bid count |
+| **bidTransactions** | Bid purchase/usage history |
+| **autoBidConfigs** | Automated bidding settings |
+| **digitalProducts** | Downloadable/access products |
+| **digitalPurchases** | Digital product purchases |
+| **minuteServices** | Time-based services |
+| **serviceSessions** | Service session records |
+| **serviceUsage** | Platform usage tracking |
+| **serviceBilling** | Periodic billing records |
+| **serviceBillingItems** | Billing line items |
+
+## Traditional Auctions
+
+Standard ascending bid auctions where the highest bidder wins when time expires.
+
+### Schema: `auctions`
+
+```typescript
+{
+  title: string,
+  description?: string,
+  categoryId: Id<"categories">,
+  condition?: "new" | "like_new" | "good" | "fair",
+  startingBid: number,
+  currentBid: number,
+  startTime: number,      // Timestamp
+  endTime: number,        // Timestamp
+  imageUrl?: string,
+  sellerId: Id<"users">,
+  highestBidderId?: Id<"users">,
+  status: "pending" | "active" | "completed" | "cancelled",
+  isDisabled: boolean,
+  reservePrice?: number,  // Minimum price to sell
+  buyNowPrice?: number,   // Instant purchase price
+}
+```
+
+### API Functions
+
+```typescript
+// Get active auctions
+const auctions = useQuery(api.auctions.getActiveAuctions, {
+  categoryId: optional,
+  limit: 20
+});
+
+// Get auction details
+const auction = useQuery(api.auctions.getAuctionById, {
+  auctionId: "..."
+});
+
+// Place a bid
+await convex.mutation(api.auctions.placeBid, {
+  auctionId: "...",
+  amount: 150.00
+});
+
+// Buy now (instant purchase)
+await convex.mutation(api.auctions.buyNow, {
+  auctionId: "..."
+});
+```
+
+## Penny Auctions
+
+Timer-based auctions where each bid extends the timer and increments the price.
+
+### How Penny Auctions Work
+
+1. User purchases a bid package (e.g., 100 bids for $50)
+2. Each bid costs one bid from the user's balance
+3. Each bid:
+   - Increases price by a small increment (e.g., $0.01)
+   - Extends the timer by a few seconds (e.g., 10 seconds)
+   - Makes the bidder the current winner
+4. When timer reaches zero, the last bidder wins
+5. Winner pays the final price (often 90%+ off retail)
+
+### Schema: `pennyAuctions`
+
+```typescript
+{
+  title: string,
+  description?: string,
+  categoryId: Id<"categories">,
+  imageUrl?: string,
+  retailPrice: number,      // Original product value
+  startingPrice: number,    // Usually $0
+  currentPrice: number,     // Current price
+  bidIncrement: number,     // Price increase per bid ($0.01)
+  bidCost: number,          // Cost per bid ($0.50)
+  startTime: number,
+  endTime: number,          // Extends with each bid
+  timerSeconds: number,     // Seconds added per bid
+  status: "pending" | "active" | "completed" | "cancelled",
+  highestBidderId?: Id<"users">,
+  totalBids: number,
+  isDisabled: boolean,
+  sellerId: Id<"users">,
+  featured: boolean,
+  winnerId?: Id<"users">,
+  finalPrice?: number,
+}
+```
+
+### Bid Packages
+
+```typescript
+{
+  name: string,             // "Starter Pack"
+  description?: string,
+  bidCount: number,         // 100
+  price: number,            // $50
+  isActive: boolean,
+  discountPercentage: number,
+  imageUrl?: string,
+  featured: boolean,
+}
+```
+
+### API Functions
+
+```typescript
+// Get active penny auctions
+const auctions = useQuery(api.pennyAuctions.getActivePennyAuctions, {
+  featured: true,
+  limit: 10
+});
+
+// Place a penny bid (uses 1 bid from balance)
+await convex.mutation(api.pennyAuctions.placePennyBid, {
+  auctionId: "..."
+});
+
+// Get bid packages
+const packages = useQuery(api.bidPackages.getBidPackages, {});
+
+// Purchase bid package
+const { transactionId } = await convex.mutation(
+  api.bidPackages.initiatePurchase,
+  { packageId: "..." }
+);
+
+// Get user's bid balance
+const balance = useQuery(api.bidPackages.getUserBidBalance, {});
+
+// Set up auto-bid
+await convex.mutation(api.pennyAuctions.setupAutoBid, {
+  auctionId: "...",
+  maxBids: 50,
+  stopWhenOutbid: true
+});
+```
+
+## Digital Products
+
+Downloadable or access-based digital products.
+
+### Schema: `digitalProducts`
+
+```typescript
+{
+  title: string,
+  description?: string,
+  price: number,
+  salePrice?: number,
+  categoryId: Id<"categories">,
+  sellerId: Id<"users">,
+  fileUrl?: string,
+  fileKey?: string,
+  fileSize?: number,
+  fileType?: string,
+  previewUrl?: string,
+  deliveryType: "download" | "access_key" | "online_access",
+  licenseType: "single_user" | "multi_user" | "subscription",
+  subscriptionPeriod?: "monthly" | "yearly",
+  downloadLimit?: number,
+  isWatermarked: boolean,
+  status: "draft" | "active" | "inactive",
+  tags?: string[],
+  averageRating: number,
+  totalRatings: number,
+  totalSales: number,
+  allowAffiliates: boolean,
+  affiliateCommissionRate: number,
+}
+```
+
+## Minute-Based Services
+
+Services billed by the minute.
+
+### Schema: `minuteServices`
+
+```typescript
+{
+  title: string,
+  description?: string,
+  ratePerMinute: number,    // USD per minute
+  minimumMinutes: number,
+  maximumMinutes?: number,
+  maximumCharge?: number,   // Cap on total charge
+  categoryId: Id<"categories">,
+  providerId: Id<"users">,
+  isActive: boolean,
+  tags?: string[],
+  averageRating: number,
+  totalRatings: number,
+}
+```
+
+### Service Sessions
+
+```typescript
+{
+  serviceId: Id<"minuteServices">,
+  userId: Id<"users">,      // Customer
+  providerId: Id<"users">,  // Provider
+  startTime: number,
+  endTime?: number,
+  durationMinutes?: number,
+  amount: number,           // Total charge
+  status: "active" | "paused" | "completed" | "cancelled",
+  paymentStatus: "pending" | "paid" | "refunded" | "disputed",
+  paymentId?: string,
+  notes?: string,
+}
+```
+
+## Platform Billing
+
+Tracks platform service usage for billing sellers.
+
+### Service Usage
+
+```typescript
+{
+  userId: Id<"users">,
+  serviceType: "auction" | "marketplace" | "premium_listing" | "featured_product" | "analytics" | "api_access",
+  startTime: number,
+  endTime?: number,
+  durationMinutes?: number,
+  ratePerMinute: number,
+  totalCost: number,
+  status: "active" | "completed" | "billed",
+  description?: string,
+  metadata?: any,
+}
+```
+
+### Billing Records
+
+```typescript
+{
+  userId: Id<"users">,
+  billingPeriodStart: number,
+  billingPeriodEnd: number,
+  totalAmount: number,
+  status: "pending" | "paid" | "overdue" | "cancelled",
+  dueDate: number,
+  paymentDate?: number,
+  paymentMethod?: string,
+  invoiceNumber: string,
+  notes?: string,
+}
+```
+
+## Migration
+
+To migrate existing auction data to Convex:
+
+1. **Run the base migration first** (users, products, etc.)
+
+2. **Add auction migration to the script**:
+
+```javascript
+// scripts/migrate-auctions-to-convex.js
+const { ConvexHttpClient } = require("convex/browser");
+
+async function migrateAuctions(sequelize, convex, idMaps) {
+  const [auctions] = await sequelize.query("SELECT * FROM auctions");
+
+  for (const auction of auctions) {
+    const convexId = await convex.mutation(
+      "_migration/migrateAuctions:migrateAuction",
+      {
+        title: auction.title,
+        categoryId: idMaps.categories.get(auction.category_id),
+        sellerId: idMaps.users.get(auction.seller_id),
+        startingBid: parseFloat(auction.starting_bid),
+        currentBid: parseFloat(auction.current_bid),
+        startTime: new Date(auction.start_time).getTime(),
+        endTime: new Date(auction.end_time).getTime(),
+        status: auction.status,
+        // ... other fields
+      }
+    );
+    idMaps.auctions.set(auction.id, convexId);
+  }
+}
+```
+
+3. **Run migrations in order**:
+   - Users → Categories → Products
+   - Auctions → Bids
+   - Penny Auctions → Penny Bids
+   - Bid Packages → User Balances → Transactions
+
+## Indexes
+
+All tables include optimized indexes for common queries:
+
+| Table | Indexes |
+|-------|---------|
+| auctions | by_category, by_seller, by_status, by_end_time |
+| pennyAuctions | by_category, by_status, by_featured, by_end_time |
+| bids | by_auction, by_bidder, by_auction_and_amount |
+| pennyBids | by_auction, by_bidder |
+| bidPackages | by_active, by_featured |
+| userBidBalances | by_user |
+| digitalProducts | by_category, by_seller, by_status |
+| minuteServices | by_category, by_provider, by_active |
+
+## Real-time Features
+
+All auction tables support Convex's real-time subscriptions:
+
+```typescript
+// Live auction updates
+const auction = useQuery(api.auctions.getAuctionById, {
+  auctionId: "..."
+});
+// Automatically updates when bids are placed
+
+// Live penny auction with timer
+const pennyAuction = useQuery(api.pennyAuctions.getPennyAuctionById, {
+  auctionId: "..."
+});
+// Updates in real-time as bids come in
+```
+
+## Scheduled Functions
+
+For auction management, set up scheduled functions:
+
+```typescript
+// convex/crons.ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+// Check for ended auctions every minute
+crons.interval(
+  "check-ended-auctions",
+  { minutes: 1 },
+  internal.auctions.checkEndedAuctions
+);
+
+// Check for ended penny auctions every 10 seconds
+crons.interval(
+  "check-ended-penny-auctions",
+  { seconds: 10 },
+  internal.pennyAuctions.checkEndedPennyAuctions
+);
+
+export default crons;
+```
+
+## Security Considerations
+
+1. **Bid Validation**: All bids are validated server-side
+2. **Balance Checks**: Penny bids verify user has sufficient balance
+3. **Ownership Checks**: Sellers can't bid on their own auctions
+4. **Rate Limiting**: Consider adding rate limits for bid placement
+5. **Audit Trail**: All bid transactions are logged

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "test": "jest --forceExit --detectOpenHandles",
     "convex:dev": "convex dev",
     "convex:deploy": "convex deploy",
-    "migrate:convex": "node scripts/migrate-to-convex.js"
+    "migrate:convex": "node scripts/migrate-to-convex.js",
+    "deploy:rapid": "bash scripts/rapid-deploy.sh",
+    "verify:migration": "node scripts/verify-migration.js",
+    "cleanup:legacy": "node scripts/cleanup-legacy.js"
   }
 }

--- a/scripts/rapid-deploy.sh
+++ b/scripts/rapid-deploy.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# ===========================================
+# RAPID CONVEX DEPLOYMENT SCRIPT
+# Run this to go live in 2 days
+# ===========================================
+
+set -e  # Exit on error
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}"
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║           RAPID CONVEX DEPLOYMENT - 2 DAY SPRINT           ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Step 1: Check prerequisites
+echo -e "${YELLOW}[1/8] Checking prerequisites...${NC}"
+
+if ! command -v node &> /dev/null; then
+    echo -e "${RED}❌ Node.js not found. Please install Node.js 18+${NC}"
+    exit 1
+fi
+
+if ! command -v npx &> /dev/null; then
+    echo -e "${RED}❌ npx not found. Please install npm${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Prerequisites OK${NC}"
+
+# Step 2: Install dependencies
+echo -e "${YELLOW}[2/8] Installing dependencies...${NC}"
+npm install
+echo -e "${GREEN}✅ Dependencies installed${NC}"
+
+# Step 3: Check for Convex project
+echo -e "${YELLOW}[3/8] Checking Convex configuration...${NC}"
+
+if [ -z "$CONVEX_URL" ] && [ -z "$CONVEX_DEPLOYMENT" ]; then
+    echo -e "${YELLOW}⚠️  CONVEX_URL not set. Initializing Convex...${NC}"
+    echo ""
+    echo -e "${BLUE}This will open Convex setup. Please:${NC}"
+    echo "  1. Log in to Convex"
+    echo "  2. Create a new project (or select existing)"
+    echo "  3. Copy the deployment URL"
+    echo ""
+    read -p "Press Enter to continue..."
+    npx convex dev --once
+    echo ""
+    echo -e "${YELLOW}Please add to your .env file:${NC}"
+    echo "CONVEX_URL=<your-deployment-url>"
+    echo ""
+    read -p "Press Enter after updating .env..."
+fi
+
+echo -e "${GREEN}✅ Convex configured${NC}"
+
+# Step 4: Deploy Convex functions
+echo -e "${YELLOW}[4/8] Deploying Convex functions...${NC}"
+npx convex deploy
+echo -e "${GREEN}✅ Convex functions deployed${NC}"
+
+# Step 5: Backup PostgreSQL (if DATABASE_URL is set)
+echo -e "${YELLOW}[5/8] Database backup...${NC}"
+
+if [ -n "$DATABASE_URL" ]; then
+    BACKUP_FILE="backup_$(date +%Y%m%d_%H%M%S).sql"
+    echo "Creating backup: $BACKUP_FILE"
+
+    # Extract connection details and backup
+    # Note: This is a simplified version - adjust for your setup
+    if command -v pg_dump &> /dev/null; then
+        pg_dump "$DATABASE_URL" > "$BACKUP_FILE" 2>/dev/null || echo "⚠️  Backup skipped (pg_dump not available or connection failed)"
+    else
+        echo "⚠️  pg_dump not available - please backup manually"
+    fi
+else
+    echo "⚠️  DATABASE_URL not set - skipping backup"
+fi
+
+echo -e "${GREEN}✅ Backup step complete${NC}"
+
+# Step 6: Run data migration
+echo -e "${YELLOW}[6/8] Running data migration...${NC}"
+
+if [ -f "scripts/migrate-to-convex.js" ]; then
+    read -p "Run data migration now? (y/N) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        npm run migrate:convex
+        echo -e "${GREEN}✅ Migration complete${NC}"
+    else
+        echo "⚠️  Migration skipped - run 'npm run migrate:convex' manually"
+    fi
+else
+    echo "⚠️  Migration script not found"
+fi
+
+# Step 7: Enable hybrid controllers
+echo -e "${YELLOW}[7/8] Enabling hybrid mode...${NC}"
+
+# Backup original controllers
+if [ -f "src/controllers/productController.js" ] && [ ! -f "src/controllers/productController.pg.js" ]; then
+    cp src/controllers/productController.js src/controllers/productController.pg.js
+    echo "  Backed up productController.js → productController.pg.js"
+fi
+
+# Optionally swap to hybrid controller
+read -p "Enable hybrid product controller? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    if [ -f "src/controllers/productController.hybrid.js" ]; then
+        cp src/controllers/productController.hybrid.js src/controllers/productController.js
+        echo -e "${GREEN}✅ Hybrid controller enabled${NC}"
+    fi
+else
+    echo "  Using original controllers with Convex bridge"
+fi
+
+# Step 8: Start server
+echo -e "${YELLOW}[8/8] Ready to start!${NC}"
+
+echo ""
+echo -e "${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║                    DEPLOYMENT COMPLETE!                    ║${NC}"
+echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${BLUE}Next steps:${NC}"
+echo "  1. Start server:     npm run dev"
+echo "  2. Test endpoints:   curl http://localhost:5000/api/products"
+echo "  3. Check Convex:     https://dashboard.convex.dev"
+echo ""
+echo -e "${YELLOW}To rollback:${NC}"
+echo "  - Comment out convexService.initializeConvex() in server.js"
+echo "  - Or restore: cp src/controllers/productController.pg.js src/controllers/productController.js"
+echo ""

--- a/server.js
+++ b/server.js
@@ -1,8 +1,9 @@
 const express = require("express");
 const app = require("./src/app");
-const http = require('http');
+const http = require("http");
 const sequelize = require("./src/config/database");
-const socketService = require('./src/services/socketService');
+const socketService = require("./src/services/socketService");
+const convexService = require("./src/services/convexService");
 require("dotenv").config();
 
 const PORT = process.env.PORT || 5000;
@@ -10,16 +11,30 @@ const PORT = process.env.PORT || 5000;
 // Create HTTP server
 const server = http.createServer(app);
 
-// Initialize Socket.IO
+// Initialize Socket.IO (keep for now, will be replaced by Convex subscriptions)
 socketService.initializeSocket(server);
 
-// Connect to database
-sequelize.authenticate()
-  .then(() => console.log("Database connected successfully"))
-  .catch(err => console.error("Database connection failed:", err));
+// Initialize Convex (NEW)
+const convexEnabled = convexService.initializeConvex();
+if (convexEnabled) {
+  console.log("✅ Convex backend enabled - hybrid mode active");
+} else {
+  console.log("⚠️  Convex not configured - using PostgreSQL only");
+}
+
+// Make convex service available globally
+app.locals.convex = convexService;
+app.locals.useConvex = convexEnabled;
+
+// Connect to PostgreSQL (keep as fallback)
+sequelize
+  .authenticate()
+  .then(() => console.log("✅ PostgreSQL connected"))
+  .catch((err) => console.error("❌ PostgreSQL connection failed:", err));
 
 // Start server
 server.listen(PORT, "0.0.0.0", () => {
-  console.log(`Server is running on port ${PORT}`);
-  console.log(`API Documentation available at http://localhost:${PORT}/api/docs`);
+  console.log(`\n🚀 Server running on port ${PORT}`);
+  console.log(`📚 API Docs: http://localhost:${PORT}/api/docs`);
+  console.log(`\n📊 Backend Mode: ${convexEnabled ? "CONVEX + PostgreSQL (hybrid)" : "PostgreSQL only"}`);
 });

--- a/src/controllers/productController.hybrid.js
+++ b/src/controllers/productController.hybrid.js
@@ -1,0 +1,255 @@
+/**
+ * Hybrid Product Controller
+ *
+ * Uses Convex when available, falls back to PostgreSQL.
+ * Drop-in replacement for productController.js
+ */
+
+const { Product, Category, User } = require("../models");
+const { Op } = require("sequelize");
+const convexService = require("../services/convexService");
+
+// Helper: Check if Convex is available
+const useConvex = () => convexService.isConvexEnabled();
+
+// @desc Create a new product
+// @route POST /api/products
+exports.createProduct = async (req, res) => {
+  try {
+    if (req.user.role !== "seller") {
+      return res.status(403).json({ message: "Only sellers can create products" });
+    }
+
+    const { title, description, price, imageUrl, categoryId } = req.body;
+
+    if (useConvex()) {
+      // Use Convex
+      const result = await convexService.createProduct(req.user.sessionToken, {
+        title,
+        description,
+        price: parseFloat(price),
+        imageUrl,
+        categoryId,
+      });
+      return res.status(201).json({ message: "Product created successfully", product: result });
+    }
+
+    // Fallback to PostgreSQL
+    const category = await Category.findByPk(categoryId);
+    if (!category) {
+      return res.status(400).json({ message: "Invalid category ID" });
+    }
+
+    const product = await Product.create({
+      sellerId: req.user.id,
+      categoryId,
+      title,
+      description,
+      price,
+      imageUrl,
+    });
+
+    res.status(201).json({ message: "Product created successfully", product });
+  } catch (error) {
+    console.error("createProduct error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};
+
+// @desc Get all products
+// @route GET /api/products
+exports.getAllProducts = async (req, res) => {
+  try {
+    const { categoryId, sellerId, minPrice, maxPrice, search } = req.query;
+
+    if (useConvex()) {
+      // Use Convex
+      const products = await convexService.getProducts({
+        categoryId,
+        sellerId,
+        includeDisabled: false,
+      });
+
+      // Apply additional filters (Convex doesn't have all filters yet)
+      let filtered = products || [];
+      if (minPrice) filtered = filtered.filter((p) => p.price >= parseFloat(minPrice));
+      if (maxPrice) filtered = filtered.filter((p) => p.price <= parseFloat(maxPrice));
+      if (search) {
+        const s = search.toLowerCase();
+        filtered = filtered.filter(
+          (p) =>
+            p.title?.toLowerCase().includes(s) ||
+            p.description?.toLowerCase().includes(s)
+        );
+      }
+
+      return res.json(filtered);
+    }
+
+    // Fallback to PostgreSQL
+    const whereCondition = { isDisabled: false };
+    if (categoryId) whereCondition.categoryId = categoryId;
+    if (sellerId) whereCondition.sellerId = sellerId;
+    if (minPrice) whereCondition.price = { [Op.gte]: parseFloat(minPrice) };
+    if (maxPrice) {
+      whereCondition.price = { ...whereCondition.price, [Op.lte]: parseFloat(maxPrice) };
+    }
+    if (search) {
+      whereCondition[Op.or] = [
+        { title: { [Op.iLike]: `%${search}%` } },
+        { description: { [Op.iLike]: `%${search}%` } },
+      ];
+    }
+
+    const products = await Product.findAll({
+      where: whereCondition,
+      include: [
+        { model: Category, attributes: ["id", "name"] },
+        { model: User, attributes: ["id", "name"] },
+      ],
+    });
+
+    res.json(products);
+  } catch (error) {
+    console.error("getAllProducts error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};
+
+// @desc Get a single product by ID
+// @route GET /api/products/:id
+exports.getProductById = async (req, res) => {
+  try {
+    if (useConvex()) {
+      const product = await convexService.getProductById(req.params.id);
+      if (!product) {
+        return res.status(404).json({ message: "Product not found" });
+      }
+      return res.json(product);
+    }
+
+    // Fallback to PostgreSQL
+    const product = await Product.findByPk(req.params.id, {
+      include: [
+        { model: Category, attributes: ["id", "name"] },
+        { model: User, attributes: ["id", "name"] },
+      ],
+    });
+
+    if (!product || product.isDisabled) {
+      return res.status(404).json({ message: "Product not found" });
+    }
+
+    res.json(product);
+  } catch (error) {
+    console.error("getProductById error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};
+
+// @desc Update a product
+// @route PUT /api/products/:id
+exports.updateProduct = async (req, res) => {
+  try {
+    const { title, description, price, imageUrl, categoryId } = req.body;
+
+    if (useConvex()) {
+      const result = await convexService.updateProduct(
+        req.user.sessionToken,
+        req.params.id,
+        { title, description, price: price ? parseFloat(price) : undefined, imageUrl, categoryId }
+      );
+      return res.json({ message: "Product updated successfully", product: result });
+    }
+
+    // Fallback to PostgreSQL
+    const product = await Product.findByPk(req.params.id);
+    if (!product) {
+      return res.status(404).json({ message: "Product not found" });
+    }
+
+    if (product.sellerId !== req.user.id) {
+      return res.status(403).json({ message: "Unauthorized to update this product" });
+    }
+
+    if (categoryId) {
+      const category = await Category.findByPk(categoryId);
+      if (!category) {
+        return res.status(400).json({ message: "Invalid category ID" });
+      }
+      product.categoryId = categoryId;
+    }
+
+    product.title = title || product.title;
+    product.description = description || product.description;
+    product.price = price || product.price;
+    product.imageUrl = imageUrl || product.imageUrl;
+
+    await product.save();
+    res.json({ message: "Product updated successfully", product });
+  } catch (error) {
+    console.error("updateProduct error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};
+
+// @desc Delete a product
+// @route DELETE /api/products/:id
+exports.deleteProduct = async (req, res) => {
+  try {
+    if (useConvex()) {
+      await convexService.deleteProduct(req.user.sessionToken, req.params.id);
+      return res.json({ message: "Product deleted successfully" });
+    }
+
+    // Fallback to PostgreSQL
+    const product = await Product.findByPk(req.params.id);
+    if (!product) {
+      return res.status(404).json({ message: "Product not found" });
+    }
+
+    if (product.sellerId !== req.user.id) {
+      return res.status(403).json({ message: "Unauthorized to delete this product" });
+    }
+
+    await product.destroy();
+    res.json({ message: "Product deleted successfully" });
+  } catch (error) {
+    console.error("deleteProduct error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};
+
+// @desc Toggle product status
+// @route POST /api/products/:id/toggle-status
+exports.toggleProductStatus = async (req, res) => {
+  try {
+    // Use PostgreSQL for now (toggle is complex)
+    const product = await Product.findByPk(req.params.id);
+
+    if (!product) {
+      return res.status(404).json({ message: "Product not found" });
+    }
+
+    if (req.user.role === "seller") {
+      if (product.sellerId !== req.user.id) {
+        return res.status(403).json({ message: "Unauthorized to update this product" });
+      }
+      product.isDisabled = true;
+    } else if (req.user.role === "admin") {
+      product.isDisabled = !product.isDisabled;
+    } else {
+      return res.status(403).json({ message: "Access denied" });
+    }
+
+    await product.save();
+
+    res.json({
+      message: `Product has been ${product.isDisabled ? "disabled" : "enabled"} successfully.`,
+      isDisabled: product.isDisabled,
+    });
+  } catch (error) {
+    console.error("toggleProductStatus error:", error);
+    res.status(500).json({ message: "Server error", error: error.message });
+  }
+};

--- a/src/middleware/convexBridge.js
+++ b/src/middleware/convexBridge.js
@@ -1,0 +1,65 @@
+/**
+ * Convex Bridge Middleware
+ *
+ * Provides seamless fallback between Convex and PostgreSQL.
+ * Use this to gradually migrate controllers without breaking anything.
+ */
+
+const convexService = require("../services/convexService");
+
+/**
+ * Middleware that adds Convex helpers to req
+ */
+const convexBridge = (req, res, next) => {
+  req.useConvex = convexService.isConvexEnabled();
+  req.convex = convexService;
+  next();
+};
+
+/**
+ * Try Convex first, fall back to PostgreSQL
+ * @param {Function} convexFn - Async function using Convex
+ * @param {Function} pgFn - Async function using PostgreSQL
+ */
+const tryConvexFirst = async (convexFn, pgFn) => {
+  if (convexService.isConvexEnabled()) {
+    try {
+      return await convexFn();
+    } catch (error) {
+      console.warn("Convex failed, falling back to PostgreSQL:", error.message);
+      return await pgFn();
+    }
+  }
+  return await pgFn();
+};
+
+/**
+ * Wrapper for controller functions to add Convex support
+ * @param {Object} options
+ * @param {Function} options.convex - Convex implementation
+ * @param {Function} options.postgres - PostgreSQL implementation
+ */
+const hybridController = ({ convex, postgres }) => {
+  return async (req, res) => {
+    try {
+      if (convexService.isConvexEnabled()) {
+        try {
+          return await convex(req, res);
+        } catch (error) {
+          console.warn("Convex error, falling back:", error.message);
+          return await postgres(req, res);
+        }
+      }
+      return await postgres(req, res);
+    } catch (error) {
+      console.error("Controller error:", error);
+      res.status(500).json({ message: "Server error", error: error.message });
+    }
+  };
+};
+
+module.exports = {
+  convexBridge,
+  tryConvexFirst,
+  hybridController,
+};


### PR DESCRIPTION
Adds 15 new tables to support:

1. Traditional Auctions:
   - auctions: Ascending bid auctions with reserve/buy-now
   - bids: Bid records with winning status

2. Penny Auctions:
   - pennyAuctions: Timer-based auctions with paid bids
   - pennyBids: Individual penny bid records
   - bidPackages: Purchasable bid packs
   - userBidBalances: User's available bids
   - bidTransactions: Purchase/usage history
   - autoBidConfigs: Automated bidding settings

3. Digital Products:
   - digitalProducts: Downloadable/access products
   - digitalPurchases: Purchase records

4. Minute-Based Services:
   - minuteServices: Time-based services
   - serviceSessions: Session records

5. Platform Billing:
   - serviceUsage: Usage tracking
   - serviceBilling: Periodic billing
   - serviceBillingItems: Line items

Includes:
- Full CRUD operations for auctions
- Penny auction bidding with balance management
- Bid package purchase flow
- Migration utilities for all new tables
- Comprehensive documentation

See docs/EXTENDED_SCHEMA.md for details.